### PR TITLE
Making EPF File Generation less generically named

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,37 @@
+# Maximum example, remove per project as needed
+engines:
+  scss-lint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - ruby
+  eslint:
+    enabled: true
+    extensions:
+      - .es6
+      - .js
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+
+ratings:
+  paths:
+  - Gemfile.lock
+  - "lib/**"
+  - "**.erb"
+  - "**.haml"
+  - "**.rb"
+  - "**.rhtml"
+  - "**.slim"
+  - "**.ngslim"
+  - "**.css"
+  - "**.coffee"
+  - "**.js"
+  - "**.es6"
+exclude_paths:
+  - spec/
+  - vendor/
+  - db/schema.rb

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+**/*{.,-}min.js
+
+coverage
+karma.conf.js
+tmp
+node_modules/**
+vendor/assets/bower_components/**
+js_spec

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,128 @@
+{
+  "env": {
+    "browser": true,
+    "jasmine": true,
+    "node": true,
+    "es6": true
+  },
+  "globals": {
+    "angular": false,
+    "$": false,
+    "_": false,
+    "LayMeOut": false,
+    "moment": false,
+    "fixture": false,
+    "inject": false
+  },
+  "rules": {
+    "no-bitwise": 2,
+    "camelcase": [
+      2,
+      {
+        "properties": "always"
+      }
+    ],
+    "curly": [
+      2,
+      "all"
+    ],
+    "eqeqeq": 2,
+    "guard-for-in": 2,
+    "no-extend-native": 2,
+    "wrap-iife": 2,
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1,
+        "VariableDeclarator": 2
+      }
+    ],
+    "no-use-before-define": 2,
+    "new-cap": 2,
+    "no-caller": 2,
+    "no-empty": 0,
+    "no-irregular-whitespace": 2,
+    "no-new": 2,
+    "no-plusplus": 0,
+    "quotes": [
+      2,
+      "single"
+    ],
+    "no-undef": 2,
+    "no-unused-vars": 0,
+    "strict": 0,
+    "max-params": [
+      2,
+      10
+    ],
+    "max-depth": [
+      2,
+      5
+    ],
+    "max-statements": [
+      2,
+      40
+    ],
+    "complexity": [
+      2,
+      8
+    ],
+    "max-len": [
+      2,
+      120
+    ],
+    "semi": 0,
+    "no-cond-assign": 0,
+    "no-debugger": 0,
+    "no-eq-null": 2,
+    "no-eval": 0,
+    "no-unused-expressions": 0,
+    "block-scoped-var": 0,
+    "no-iterator": 0,
+    "linebreak-style": 0,
+    "comma-style": 0,
+    "no-loop-func": 2,
+    "no-multi-str": 2,
+    "valid-typeof": 0,
+    "no-proto": 0,
+    "no-script-url": 0,
+    "no-shadow": 2,
+    "dot-notation": 0,
+    "no-new-func": 0,
+    "no-new-wrappers": 0,
+    "no-invalid-this": 0,
+    "require-yield": 0,
+    "operator-linebreak": [
+      2,
+      "after"
+    ],
+    "no-mixed-spaces-and-tabs": 2,
+    "no-trailing-spaces": 2,
+    "space-unary-ops": 0,
+    "one-var": 0,
+    "space-return-throw-case": 0,
+    "space-after-keywords": [
+      2,
+      "always"
+    ],
+    "space-infix-ops": 2,
+    "space-before-blocks": [
+      2,
+      "always"
+    ],
+    "eol-last": 2,
+    "array-bracket-spacing": [
+      2,
+      "never"
+    ],
+    "space-in-parens": [
+      2,
+      "never"
+    ],
+    "valid-jsdoc": 2,
+    "no-multiple-empty-lines": 2,
+    "no-underscore-dangle": 0,
+    "comma-dangle": 0
+  }
+}

--- a/.rubocop.hound.yml
+++ b/.rubocop.hound.yml
@@ -1,0 +1,243 @@
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/schema.rb"
+  UseCache: false
+Style/CollectionMethods:
+  Description: Preferred collection methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    find: detect
+    find_all: select
+    reduce: inject
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+Style/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+  MaxLineLength: 80
+Style/OptionHash:
+  Description: Don't use option hashes when you can use keyword arguments.
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Style/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  Exclude:
+  - spec/**/*
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineBlockParams:
+  Description: Enforces the names of some block params.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#reduce-blocks
+  Enabled: false
+  Methods:
+  - reduce:
+    - a
+    - e
+  - inject:
+    - a
+    - e
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: true
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/StringLiteralsInInterpolation:
+  Description: Checks if uses of quotes inside expressions in interpolated strings
+    match the configured preference.
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: false
+  Max: 15
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 100
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Description: A complexity metric that is strongly correlated to the number of test
+    cases needed to validate a method.
+  Enabled: false
+  Max: 6
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: false
+  CountComments: false
+  Max: 10
+Metrics/ParameterLists:
+  Description: Avoid parameter lists longer than three or four parameters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Metrics/PerceivedComplexity:
+  Description: A complexity metric geared towards measuring complexity for a human
+    reader.
+  Enabled: false
+  Max: 7
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Style/InlineComment:
+  Description: Avoid inline comments.
+  Enabled: false
+Style/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Send:
+  Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
+    may overlap with existing methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-public-send
+  Enabled: false
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/EachWithObjectArgument:
+  Description: Check for immutable argument given to each_with_object.
+  Enabled: true
+Lint/HandleExceptions:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralInCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,55 @@
+inherit_from:
+ - .rubocop.hound.yml
+
+AllCops:
+  TargetRubyVersion: 2.1
+  Exclude:
+    - '*.gemspec'
+    - 'Gemfile'
+
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Style/EmptyLinesAroundMethodBody:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+  # we don't care about kind_of? vs is_a?
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/RedundantException:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/CollectionMethods:
+  PreferredMethods:
+    detect: find
+
+# Github's PR width is 120 characters
+Metrics/LineLength:
+  Max: 120
+  AllowURI: true
+
+# Align with the style guide, we don't prefer anything
+Style/CollectionMethods:
+  Enabled: false
+
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: true
+  Max: 30

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,25 @@
+exclude:
+ - '*.min.css'
+ - 'vendor/assets/**/*'
+ - 'node_modules/**/*'
+ - 'coverage/**/*'
+
+linters:
+  ColorKeyword:
+    enabled: false
+  Indentation:
+    width: 2
+    character: "space"
+  LeadingZero:
+    style: "include_zero"
+  ColorVariable:
+    enabled: false
+  Comment:
+    enabled: false
+  SelectorDepth:
+    max_depth: 5
+  NestingDepth:
+    max_depth: 5
+  QualifyingElement:
+    allow_element_with_attribute: true
+    allow_element_with_class: true

--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-  file = AUB::Payroll::File.new company_name: "StyroPrints",
-                                date: Date.new(2000, 6, 2),
-                                transactions: [
-                                  { account_number: "001120001146", amount: 540.00 },
-                                  { account_number: "001120001146", amount: 921.00 },
-                                  { account_number: "001120001146", amount: 816.25 },
-                                  { account_number: "001120001146", amount: 500.00 },
-                                  { account_number: "001120001146", amount: 882.50 },
-                                  { account_number: "001120001146", amount: 857.50 },
-                                  { account_number: "001120001146", amount: 1_044.00 },
-                                  { account_number: "001120001146", amount: 1_612.50 }
-                                ]
-
+  file = AUB::Payroll::EPFFile.new company_name: "StyroPrints",
+                                   date: Date.new(2000, 6, 2),
+                                   transactions: [
+                                     { account_number: "001120001146", amount: 540.00 },
+                                     { account_number: "001120001146", amount: 921.00 },
+                                     { account_number: "001120001146", amount: 816.25 },
+                                     { account_number: "001120001146", amount: 500.00 },
+                                     { account_number: "001120001146", amount: 882.50 },
+                                     { account_number: "001120001146", amount: 857.50 },
+                                     { account_number: "001120001146", amount: 1_044.00 },
+                                     { account_number: "001120001146", amount: 1_612.50 }
+                                   ]
+ 
   File.write "payroll.epf", file.content
 ```
 

--- a/aub-payroll.gemspec
+++ b/aub-payroll.gemspec
@@ -4,25 +4,25 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'aub/payroll/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "aub-payroll"
+  spec.name          = 'aub-payroll'
   spec.version       = AUB::Payroll::VERSION
-  spec.authors       = ["Ronald Maravilla"]
-  spec.email         = ["rmaravilla@payrollhero.com"]
+  spec.authors       = ['Ronald Maravilla']
+  spec.email         = ['rmaravilla@payrollhero.com']
 
-  spec.summary       = %q{An AUB Payroll File Generator.}
-  spec.description   = %q{An AUB Payroll File Generator.}
-  spec.homepage      = "https://github.com/payrollhero/aub-payroll"
-  spec.license       = "BSD-3-Clause"
+  spec.summary       = 'An AUB Payroll File Generator.'
+  spec.description   = 'An AUB Payroll File Generator.'
+  spec.homepage      = 'https://github.com/payrollhero/aub-payroll'
+  spec.license       = 'BSD-3-Clause'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec'
 
-  spec.add_dependency "activesupport"
-  spec.add_dependency "activemodel"
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'activemodel'
 end

--- a/lib/aub/payroll.rb
+++ b/lib/aub/payroll.rb
@@ -8,6 +8,6 @@ module AUB
     extend ActiveSupport::Autoload
 
     autoload :Errors
-    autoload :File
+    autoload :EPFFile
   end
 end

--- a/lib/aub/payroll/epf_file.rb
+++ b/lib/aub/payroll/epf_file.rb
@@ -2,7 +2,7 @@ require "active_model"
 
 module AUB
   module Payroll
-    class File
+    class EPFFile
       extend ActiveSupport::Autoload
 
       autoload :Header

--- a/lib/aub/payroll/epf_file/footer.rb
+++ b/lib/aub/payroll/epf_file/footer.rb
@@ -1,4 +1,4 @@
-require "active_model"
+require 'active_model'
 
 module AUB
   module Payroll
@@ -17,24 +17,23 @@ module AUB
         raise Errors::Invalid, errors.full_messages.to_sentence unless valid?
       end
 
-
       def to_s
         [
-          "EF", # marks the end of file
+          'EF', # marks the end of file
           formatted_number_of_records,
           formatted_total_amount,
-          "0" * 27,
+          '0' * 27,
         ].join
       end
 
       private
 
       def formatted_number_of_records
-        "%06d" % number_of_records
+        format '%06d', number_of_records
       end
 
       def formatted_total_amount
-        "%015.2f" % total_amount
+        format '%015.2f', total_amount
       end
     end
   end

--- a/lib/aub/payroll/epf_file/footer.rb
+++ b/lib/aub/payroll/epf_file/footer.rb
@@ -2,7 +2,7 @@ require "active_model"
 
 module AUB
   module Payroll
-    class File::Footer
+    class EPFFile::Footer
       include ActiveModel::Model
 
       attr_accessor :number_of_records, :total_amount

--- a/lib/aub/payroll/epf_file/header.rb
+++ b/lib/aub/payroll/epf_file/header.rb
@@ -2,7 +2,7 @@ require "active_model"
 
 module AUB
   module Payroll
-    class File::Header
+    class EPFFile::Header
       include ActiveModel::Model
 
       attr_accessor :company_name, :date

--- a/lib/aub/payroll/epf_file/header.rb
+++ b/lib/aub/payroll/epf_file/header.rb
@@ -1,4 +1,4 @@
-require "active_model"
+require 'active_model'
 
 module AUB
   module Payroll
@@ -17,10 +17,9 @@ module AUB
         raise Errors::Invalid, errors.full_messages.to_sentence unless valid?
       end
 
-
       def to_s
         [
-          "BF", # marks the beginning of file
+          'BF', # marks the beginning of file
           formatted_company_name,
           formatted_date,
         ].join
@@ -33,7 +32,7 @@ module AUB
       end
 
       def formatted_date
-        date.strftime "%Y%m%d"
+        date.strftime '%Y%m%d'
       end
     end
   end

--- a/lib/aub/payroll/epf_file/row.rb
+++ b/lib/aub/payroll/epf_file/row.rb
@@ -1,4 +1,4 @@
-require "active_model"
+require 'active_model'
 
 module AUB
   module Payroll
@@ -17,20 +17,19 @@ module AUB
         raise Errors::Invalid, errors.full_messages.to_sentence unless valid?
       end
 
-
       def to_s
         [
-          "01",
+          '01',
           account_number,
           formatted_amount,
-          "0" * 22
+          '0' * 22
         ].join
       end
 
       private
 
       def formatted_amount
-        "%014.2f" % amount
+        format '%014.2f', amount
       end
     end
   end

--- a/lib/aub/payroll/epf_file/row.rb
+++ b/lib/aub/payroll/epf_file/row.rb
@@ -2,7 +2,7 @@ require "active_model"
 
 module AUB
   module Payroll
-    class File::Row
+    class EPFFile::Row
       include ActiveModel::Model
 
       attr_accessor :account_number, :amount

--- a/lib/aub/payroll/version.rb
+++ b/lib/aub/payroll/version.rb
@@ -1,5 +1,5 @@
 module AUB
   module Payroll
-    VERSION = "0.1.0"
+    VERSION = "0.1.0".freeze
   end
 end

--- a/spec/aub/payroll/epf_file/footer_spec.rb
+++ b/spec/aub/payroll/epf_file/footer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe AUB::Payroll::File::Footer do
+describe AUB::Payroll::EPFFile::Footer do
   subject(:footer) { described_class.new details }
 
   let(:string_version) { footer.to_s }

--- a/spec/aub/payroll/epf_file/header_spec.rb
+++ b/spec/aub/payroll/epf_file/header_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe AUB::Payroll::File::Header do
+describe AUB::Payroll::EPFFile::Header do
   subject(:header) { described_class.new details }
 
   let(:string_version) { header.to_s }

--- a/spec/aub/payroll/epf_file/row_spec.rb
+++ b/spec/aub/payroll/epf_file/row_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe AUB::Payroll::File::Row do
+describe AUB::Payroll::EPFFile::Row do
   subject(:row) { described_class.new details }
 
   let(:string_version) { row.to_s }

--- a/spec/aub/payroll/epf_file_spec.rb
+++ b/spec/aub/payroll/epf_file_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe AUB::Payroll::File do
-  subject(:file) {
+describe AUB::Payroll::EPFFile do
+  subject(:epf_file) {
     described_class.new company_name: company_name,
                         date: date,
                         transactions: transactions
@@ -25,5 +25,5 @@ describe AUB::Payroll::File do
 
   let(:expected_file_content) { File.read "spec/fixtures/payroll.epf" }
 
-  it { expect(file.content).to eq expected_file_content }
+  it { expect(epf_file.content).to eq expected_file_content }
 end


### PR DESCRIPTION
**Feature:**
This renames `AUB::Payroll::File` to `AUB::Payroll::EPFFile` to make room for PDF file as well

**Ticket:**
Adding PDF Summary Generation Support

**Submitter Checklist:**
- [x] CI Passing
- [x] No Code Climate Issues
- [x] Class, Module, and public method comments up to spec

**Reviewer Checklist:**
- [ ] New Code Tested Effectively
- [ ] Code organization meets SOP standards
- [ ] Does this code fullfill the ticket?
